### PR TITLE
Discord Connector checks

### DIFF
--- a/discord-command.inc
+++ b/discord-command.inc
@@ -15,6 +15,11 @@
 #endif
 #define _discordcmd_included
 
+#tryinclude <discord-connector>
+#if !defined dcconnector_included
+	#error To use this include you need to have "https://github.com/maddinat0r/samp-discord-connector" installed
+#endif
+
 // Config
 
 #define MAX_CMD_LEN			(50)


### PR DESCRIPTION
Simply tries to include `<discord-connector>` and then checks if the include guard set by `discord-connector` exists, if it does it means the include was included somewhere, else it will fail and ask the dev to include it